### PR TITLE
Bilag drafts: Change default nr om innslagsfelt from 3 to 5

### DIFF
--- a/regnskap/models.py
+++ b/regnskap/models.py
@@ -381,4 +381,4 @@ class BilagDraft(models.Model):
     def __unicode__(self):
         return "%s %s" % (self.dato,self.beskrivelse)
     def get_absolute_url(self):
-        return "/regnskap/registrer/%s/3?bilag_draft_id=%s" % (self.prosjekt.navn, self.id)
+        return "/regnskap/registrer/%s/5?bilag_draft_id=%s" % (self.prosjekt.navn, self.id)


### PR DESCRIPTION
Jeg bruker vanligvis 4 innslagsfelt for f.eks. medlemsregistreringer og givere som også gir til vennskapslaget, så det er ganske irriterende å endre den manuelt hver gang. Noen få ganger brukes også fem felt. Tar ikke så mye ekstra plass og kluderer ikke så mye ekstra opp om det er frem istedenfor tre felt tenker jeg.